### PR TITLE
Updated deprecated function call.

### DIFF
--- a/asix_eepromtool.c
+++ b/asix_eepromtool.c
@@ -61,7 +61,7 @@ int OpenDeviceVIDPID(unsigned int vid,unsigned int pid){
 		printf("libusb_init() failed: %s\n", libusb_error_name(status));
 		exit(0);
 	}
-	libusb_set_debug(NULL, 0);
+	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, 0);
 	
 	device = libusb_open_device_with_vid_pid(NULL, (uint16_t)vid, (uint16_t)pid);
 		if (device == NULL) {


### PR DESCRIPTION
Thanks for this excellent tool. However, when I compile, it says

``` C
asix_eepromtool.c: In function ‘OpenDeviceVIDPID’:
asix_eepromtool.c:64:2: warning: ‘libusb_set_debug’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
  libusb_set_debug(NULL, 0);
  ^~~~~~~~~~~~~~~~
In file included from asix_eepromtool.c:42:
/usr/include/libusb-1.0/libusb.h:1300:18: note: declared here
 void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
                  ^~~~~~~~~~~~~~~~
```

I updated that line according to https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html.