### PR TITLE
added pragma to suppress warning message

### DIFF
--- a/asix_eepromtool.c
+++ b/asix_eepromtool.c
@@ -61,7 +61,10 @@ int OpenDeviceVIDPID(unsigned int vid,unsigned int pid){
 		printf("libusb_init() failed: %s\n", libusb_error_name(status));
 		exit(0);
 	}
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	libusb_set_debug(NULL, 0);
+    #pragma GCC diagnostic pop
 	
 	device = libusb_open_device_with_vid_pid(NULL, (uint16_t)vid, (uint16_t)pid);
 		if (device == NULL) {


### PR DESCRIPTION
You said
> I'd be happy to merge a PR that gets rid of the warning without breaking backwards compatibility.

So here it is, it suppresses the warning messages. I am not sure if this helps with anything. I created this in case you find it useful. You don't have to merge it, if you don't like it. 
